### PR TITLE
fix: subTypeはキャッシュされたオブジェクトだけを使うように修正

### DIFF
--- a/examples/golang/data.go
+++ b/examples/golang/data.go
@@ -30,18 +30,19 @@ type Device struct {
 }
 
 type Base struct {
-	Id        StringOrNull   `json:"id"`
-	IsActive  BoolOrNull     `json:"is_active"`
-	Age       Int64OrNull    `json:"age"`
-	Name      StringOrNull   `json:"name"`
-	Gender    StringOrNull   `json:"gender"`
-	EyeColor  interface{}    `json:"eye_color"`
-	HairStyle *HairStyle     `json:"hair_style"`
-	Salery    Int64OrNull    `json:"salery"`
-	Friends   []*Friends     `json:"friends"`
-	Groups    []Int64OrNull  `json:"groups"`
-	Rooms     []StringOrNull `json:"rooms"`
-	Device    *Device        `json:"device"`
+	Id             StringOrNull   `json:"id"`
+	IsActive       BoolOrNull     `json:"is_active"`
+	Age            Int64OrNull    `json:"age"`
+	Name           StringOrNull   `json:"name"`
+	Gender         StringOrNull   `json:"gender"`
+	EyeColor       interface{}    `json:"eye_color"`
+	HairStyle      *HairStyle     `json:"hair_style"`
+	Salery         Int64OrNull    `json:"salery"`
+	Friends        []*Friends     `json:"friends"`
+	Groups         []Int64OrNull  `json:"groups"`
+	Rooms          []StringOrNull `json:"rooms"`
+	Device         *Device        `json:"device"`
+	Qualifications []interface{}  `json:"qualifications"`
 }
 
 // データの識別子
@@ -55,10 +56,12 @@ const (
 	Test01Base1      DataID = "Test01Base1"
 	Test02Friends2   DataID = "Test02Friends2"
 	Test02Base1      DataID = "Test02Base1"
+	Test03Base1      DataID = "Test03Base1"
 	Test04Friends3   DataID = "Test04Friends3"
 	Test04Base1      DataID = "Test04Base1"
 	Test05Device1    DataID = "Test05Device1"
 	Test05Base1      DataID = "Test05Base1"
+	Test06Base1      DataID = "Test06Base1"
 )
 
 // データ登録
@@ -138,6 +141,12 @@ func RegisterData() {
 			3,
 			4,
 		}
+		data.Qualifications = []interface{}{}
+		return data
+	})
+	f.Register(Test03Base1, func() interface{} {
+		data := f.InheritNode(Test02Base1).(*Base)
+		data.Qualifications = []interface{}{}
 		return data
 	})
 	f.Register(Test04Friends3, func() interface{} {
@@ -153,6 +162,7 @@ func RegisterData() {
 			f.ChildNode(Test01Friends2).(*Friends),
 			f.ChildNode(Test04Friends3).(*Friends),
 		}
+		data.Qualifications = []interface{}{}
 		return data
 	})
 	f.Register(Test05Device1, func() interface{} {
@@ -160,9 +170,14 @@ func RegisterData() {
 	})
 	f.Register(Test05Base1, func() interface{} {
 		return &Base{
-			Id:       "05",
-			Device:   f.ChildNode(Test05Device1).(*Device),
-			EyeColor: nil,
+			Id:     "05",
+			Device: f.ChildNode(Test05Device1).(*Device),
+		}
+	})
+	f.Register(Test06Base1, func() interface{} {
+		return &Base{
+			Id:             "06",
+			Qualifications: []interface{}{},
 		}
 	})
 }
@@ -170,7 +185,8 @@ func RegisterData() {
 var TestData = map[string]DataID{
 	"test01.json": Test01Base1,
 	"test02.json": Test02Base1,
-	"test03.json": Test02Base1,
+	"test03.json": Test03Base1,
 	"test04.json": Test04Base1,
 	"test05.json": Test05Base1,
+	"test06.json": Test06Base1,
 }

--- a/examples/json/test06.json
+++ b/examples/json/test06.json
@@ -1,0 +1,4 @@
+{
+  "id": "06",
+  "qualifications": []
+}

--- a/examples/typescript/data.ts
+++ b/examples/typescript/data.ts
@@ -36,6 +36,7 @@ export interface Base {
   groups: number[];
   rooms: string[];
   device: Device;
+  qualifications: unknown[];
 }
 
 // データの識別子
@@ -49,10 +50,12 @@ export type MyDataId =
   | 'TEST01_BASE_1'
   | 'TEST02_FRIENDS_2'
   | 'TEST02_BASE_1'
+  | 'TEST03_BASE_1'
   | 'TEST04_FRIENDS_3'
   | 'TEST04_BASE_1'
   | 'TEST05_DEVICE_1'
-  | 'TEST05_BASE_1';
+  | 'TEST05_BASE_1'
+  | 'TEST06_BASE_1';
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace DATAID {
   export const TEST01_ANDROID_1: MyDataId = 'TEST01_ANDROID_1';
@@ -64,10 +67,12 @@ export namespace DATAID {
   export const TEST01_BASE_1: MyDataId = 'TEST01_BASE_1';
   export const TEST02_FRIENDS_2: MyDataId = 'TEST02_FRIENDS_2';
   export const TEST02_BASE_1: MyDataId = 'TEST02_BASE_1';
+  export const TEST03_BASE_1: MyDataId = 'TEST03_BASE_1';
   export const TEST04_FRIENDS_3: MyDataId = 'TEST04_FRIENDS_3';
   export const TEST04_BASE_1: MyDataId = 'TEST04_BASE_1';
   export const TEST05_DEVICE_1: MyDataId = 'TEST05_DEVICE_1';
   export const TEST05_BASE_1: MyDataId = 'TEST05_BASE_1';
+  export const TEST06_BASE_1: MyDataId = 'TEST06_BASE_1';
 }
 
 // データ登録
@@ -132,6 +137,12 @@ export function registerData() {
     data.is_active = false;
     data.friends[1] = f.childNode(DATAID.TEST02_FRIENDS_2) as Friends;
     data.groups = [1, 2, 3, 4];
+    data.qualifications = [] as unknown[];
+    return data;
+  });
+  f.register(DATAID.TEST03_BASE_1, () => {
+    const data = f.inheritNode(DATAID.TEST02_BASE_1) as Base;
+    data.qualifications = [] as unknown[];
     return data;
   });
   f.register(DATAID.TEST04_FRIENDS_3, () => {
@@ -147,6 +158,7 @@ export function registerData() {
       f.childNode(DATAID.TEST01_FRIENDS_2) as Friends,
       f.childNode(DATAID.TEST04_FRIENDS_3) as Friends,
     ];
+    data.qualifications = [] as unknown[];
     return data;
   });
   f.register(DATAID.TEST05_DEVICE_1, () => {
@@ -158,12 +170,19 @@ export function registerData() {
       device: f.childNode(DATAID.TEST05_DEVICE_1) as Device,
     } as Base;
   });
+  f.register(DATAID.TEST06_BASE_1, () => {
+    return {
+      id: '06',
+      qualifications: [] as unknown[],
+    } as Base;
+  });
 }
 
 export const TestData = {
   'test01.json': DATAID.TEST01_BASE_1,
   'test02.json': DATAID.TEST02_BASE_1,
-  'test03.json': DATAID.TEST02_BASE_1,
+  'test03.json': DATAID.TEST03_BASE_1,
   'test04.json': DATAID.TEST04_BASE_1,
   'test05.json': DATAID.TEST05_BASE_1,
+  'test06.json': DATAID.TEST06_BASE_1,
 };

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -39,16 +39,17 @@ export class JsonParseResult {
     return s;
   }
 
-  putSubType(subType: SubType) {
+  putSubType(subType: SubType): SubType {
     const cached = this._subTypes.get(subType.key);
     if (cached) {
       if (cached.compare(subType)) {
-        return;
+        return cached;
       }
       cached.mergeFields(subType);
-      subType.mergeFields(cached);
+      return cached;
     } else {
       this._subTypes.add(subType);
+      return subType;
     }
   }
 
@@ -271,7 +272,8 @@ export class JsonParser {
         throw new InvalidArgumentError(`unknown systemType: ${field.fieldName} ${field.systemType}`);
       }
     }
-    this.result.putSubType(subType);
+    const cachedSubType = this.result.putSubType(subType);
+    dataSubType.updateCachedSubType(cachedSubType);
     return dataSubType;
   }
 }


### PR DESCRIPTION
- 配列が空のデータは型が不定になるが、そういうデータを処理するとエラーになる不具合を修正
- 継承するデータの対象も遡って元を探すように修正
- SystemTypeがUnknownなデータの出力がなかったり中途半端だったので修正